### PR TITLE
Upgrading less compiler to the 1.3.x branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "natural": "0.0.65",
     "handlebars": "1.0.5beta",
     "wrench": "1.3.x",
-    "less": "1.2.x",
+    "less": "1.3.x",
     "stylus": "0.30.x",
     "sass": "0.5.x",
     "optimist": "0.3.x",


### PR DESCRIPTION
I have a project that includes twitter bootstrap. The 1.2 version of less won't compile and throws errors. moving to the latest 1.3 branch fixes this issue.
