### PR TITLE
Fix 10.x sections showing up in 1.x section

### DIFF
--- a/bin/kss-node
+++ b/bin/kss-node
@@ -353,7 +353,7 @@ handlebars.registerHelper('eachSection', function(query) {
 		i, l, buffer = "";
 
 	if (!query.match(/x|\*/g)) {
-		query = new RegExp(query + ".*");
+		query = new RegExp('^' + query + '$|^' + query + "\\..*");
 	}
 	sections = styleguide.section(query);
 	if (!sections) return '';


### PR DESCRIPTION
- The eachSection regex was allowing more sections to qualify than it
  should have.
- For example, when rootNumber is 1, sections labeled 10.\* and 10
  were also matching, thus having all the sections for 10 repeated
  under section 1.
- This update will have it now match either '1', '1.', or '1.*'

Test suite still passed and sections now show up correctly.
