### PR TITLE
Compass Sprite imports break KSS parsing

### DIFF
--- a/lib/kss.js
+++ b/lib/kss.js
@@ -12,6 +12,7 @@ var walk = require('./walk.js'),
 	natural = require('natural'),
 	traverse, parse, parseChunk, checkReference, findBlocks, processMarkup,
 	isDeprecated, isExperimental, hasPrefix,
+	sassImportExpression = /@import/,
 	commentExpressions = {
 		single: /\s*?\/\/(.*?)$/g,
 		multiStart: /\/\*\!?(.*?)$/,
@@ -302,7 +303,7 @@ createModifiers = function(lines, options) {
  */
 findBlocks = function(input, options) {
 	var currentBlock = '', insideSingleBlock = false, insideMultiBlock = false,
-		isSingle = true, isMultiStart = true,
+		isSingle = true, isMultiStart = true, isSassImport = false,
 		blocks = [],
 		lines, line, i, l;
 
@@ -315,8 +316,15 @@ findBlocks = function(input, options) {
 	for (i = 0; i < l; i += 1) {
 		line = lines[i];
 
+		isSassImport = line.match(sassImportExpression);
 		isSingle = line.match(commentExpressions.single);
 		isMultiStart = line.match(commentExpressions.multiStart);
+
+		// SASS/Compass may have icon imports like "folder/*.png" that match isMultiStart
+		// but are not
+		if (!insideMultiBlock && isSassImport) {
+			continue;
+		}
 
 		// Multi-line parsing
 		if (!insideSingleBlock && isMultiStart) {


### PR DESCRIPTION
- Compass Sprite imports can be of the form `@import "folder/*.png"`.
- This matches the regex for multi-line comments and the rest of the
  file would then be ignored.
- New behaviour is to `continue` if we aren't already in a multi-line
  comment if the line starts with @import.
- Ran mocha test suite and still passed.
- Manually verified as well.
