### PR TITLE
Update package.json to fix CSS generation when generating from css where @charset is first in css file

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "stylus": "0.30.x",
     "sass": "0.5.x",
     "optimist": "0.3.x",
-    "clean-css": "0.3.x",
+    "clean-css": "1.1.x",
     "async": "0.1.x"
   },
   "devDependencies": {


### PR DESCRIPTION
updated the clean-css dependency because this version caused problems when generating a styleguide from CSS when the first characters in the CSS file are @charset .  This line is generated in my case.  I updated the version of clean-css and everything worked fine.
