### PR TITLE
Adding Licence

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,7 @@
+Copyright © 2014 Hugh Kennedy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/hughsk/kss-node.git"
-  },
+  }, 
+  "licence": "MIT",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/mocha/bin/_mocha -u tdd --reporter spec"


### PR DESCRIPTION
Hey, 

We really love your project and want to use it on one of our projects however our legal team is stopping us because it doesn't have a licence. You mentioned in the readme "Forking, hacking, tearing apart of this module welcome - it still needs some cleaning up", would it be possible to declare this in legal parlance i.e. adding a licence? 

This PR adds the MIT licence which allows anyone to do what they want with it and it the same as [KSS uses](https://github.com/kneath/kss/blob/master/LICENSE)

I hope you can help us use your awesome library!

Thanks,
James
