### PR TITLE
Add optional injection of external templates for sections.

### DIFF
--- a/bin/kss-node
+++ b/bin/kss-node
@@ -367,6 +367,28 @@ handlebars.registerHelper('eachSection', function(query) {
 });
 
 /**
+* If the template exists as *reference*.html in the templates folder, inject it.
+* Only triggered if markup is not given in the KSS documentation explicitly.
+* @param  {String|Number} reference The reference number to search for.
+*/
+handlebars.registerHelper('loadSectionTemplate', function (context) {
+	var template;
+
+	if (!options.templateDirectory)
+		return;
+
+	try {
+		template = fs.readFileSync(path.relative(process.cwd(), options.templateDirectory) + '/' + context.reference + '.hbs', 'utf8');
+	} catch (e) {
+		return;
+	}
+
+	console.log("...injecting template for section " + context.reference);
+
+	return handlebars.compile(template)(context);
+});
+
+/**
  * Loop over each section root, i.e. each section only one level deep.
  */
 handlebars.registerHelper('eachRoot', function() {

--- a/lib/template/index.html
+++ b/lib/template/index.html
@@ -80,6 +80,10 @@
                 {{#if description}}
                   {{html description}}
                 {{/if}}
+                {{{loadSectionTemplate}}}
+                <div class="kss-markup">
+                  <pre class="prettyprint lang-html">{{loadSectionTemplate}}</pre>
+                </div>
             {{/ifAny}}
           {{#whenDepth 1}} {{else}}
             </section>


### PR DESCRIPTION
We needed this functionality urgently at my company, so I thought I'd share. If a user does not specify markup in his or her KSS documentation, kss-node will scan the template directory (if provided) for .hbs files titled the same as the section being generated. If one is found, the markup is injected, alongside a code snippet.

Would appreciate any feedback!
