### PR TITLE
Update mocha from 0.14 to 1.22.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "async": "0.1.x"
   },
   "devDependencies": {
-    "mocha": "0.14.x"
+    "mocha": "1.x"
   },
   "homepage": "http://kss-node.github.com/kss-node"
 }


### PR DESCRIPTION
With mocha 0.14.x, we're getting warnings during `npm update`:

```
npm WARN engine mocha@0.14.1: wanted: {"node":">= 0.4.x < 0.8.0"} (current: {"node":"v0.10.29","npm":"1.4.18"})
```

mocha is now on 1.22.x, so we're pretty far out-of-date.
