### PR TITLE
Prevent hidden files (like .svn folders) from being copied from template.

### DIFF
--- a/bin/kss-node
+++ b/bin/kss-node
@@ -79,7 +79,13 @@ if (argv.init) {
 	}
 
 	console.log('Creating a new styleguide template...');
-	wrench.copyDirSyncRecursive( __dirname + '/../lib/template', argv.init );
+	try {
+		wrench.copyDirSyncRecursive( __dirname + '/../lib/template', argv.init );
+	}
+	catch (e) {
+		console.log('Error! ' + argv.init + ' already exists.');
+		return;
+	}
 	console.log('You can change it as you like, and use it with your styleguide like so:');
 	console.log('');
 	console.log('kss-node [sourcedir] --template "'+argv.init+'"');
@@ -115,7 +121,11 @@ try {
 
 wrench.copyDirSyncRecursive(
 	config.templateDirectory + '/public',
-	config.destinationDirectory + '/public'
+	config.destinationDirectory + '/public',
+	{
+	  forceDelete: true,
+	  excludeHiddenUnix: true
+	}
 );
 
 // Generate the static HTML pages in the next tick, i.e. after the other functions have

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "marked": "0.1.x",
     "natural": "0.0.65",
     "handlebars": "1.3.x",
-    "wrench": "1.3.x",
+    "wrench": "1.5.x",
     "less": "1.x.x",
     "stylus": "0.46.x",
     "sass": "0.5.x",


### PR DESCRIPTION
Fixes #40
