### PR TITLE
Correct replacement for ifAny helper in deprecation warning

### DIFF
--- a/bin/kss-node
+++ b/bin/kss-node
@@ -493,7 +493,7 @@ handlebars.registerHelper('ifAny', function() {
 	// Warn the user that IfAny is deprecated. The only usage in kss-node was
 	// {{#ifAny markup modifiers}} and, since modifiers is an object and, always
 	// evals to true (even when empty), #ifAny was effectively a dupe of #If.
-	console.log('IfAny is deprecated; if your template has {{#ifAny markup modifiers}}...{{/ifAny}}, replace it with {{#ifAny markup}}...{{/if}}.');
+	console.log('IfAny is deprecated; if your template has {{#ifAny markup modifiers}}...{{/ifAny}}, replace it with {{#if markup}}...{{/if}}.');
 
 	for (i = 0; i < numItems; i += 1) {
 		if (!arguments[i]) {


### PR DESCRIPTION
The "ifAny" helper should be replaced with the "if" helper.
