### PR TITLE
Load custom Handlebar helpers located in "helpers" dir

### DIFF
--- a/bin/kss-node
+++ b/bin/kss-node
@@ -18,7 +18,8 @@ var kss = require(__dirname + '/../lib/kss.js'),
 	options = {
 		templateDirectory: __dirname + '/../lib/template',
 		sourceDirectory: __dirname + '/../demo',
-		destinationDirectory: process.cwd() + '/styleguide'
+		destinationDirectory: process.cwd() + '/styleguide',
+		helpersDirectory: __dirname + '/../helpers'
 	},
 	KSS_FAILED = false,	argv;
 
@@ -313,6 +314,16 @@ jsonModifiers = function(modifiers) {
 		};
 	});
 };
+
+// Load custom Handlebars helpers
+var helperFiles = fs.readdirSync('helpers');
+
+helperFiles.forEach(function(fileName) {
+	var helper = require(config.helpersDirectory + '/' + fileName);
+	if (typeof helper.register === 'function') {
+	    helper.register(handlebars);
+	}
+});
 
 /**
  * Equivalent to the {#if} block helper with multiple arguments.


### PR DESCRIPTION
Custom Handlebar helpers is a handy way of customizing the kss-node output.

It would be nice if there was some simple built-in way of loading these, like placing files in a given folder

It could be something like the attached pull request, that would read files from a "helpers" directory, given that they were written something like this:

**helpers/foo.js**

```
module.exports.register = function (Handlebars, options)  { 
    Handlebars.registerHelper('foo', function (str)  { 
        return 'foo';
    });
};
```
