### PR TITLE
Load custom Handlebar helpers located in "helpers" dir

### DIFF
--- a/test/kss-node.js
+++ b/test/kss-node.js
@@ -16,7 +16,6 @@ suite('#kss-node', function() {
 	suite('load-path option', function() {
 		test('Fails without load-path, when using --sass', function(done) {
 			exec('bin/kss-node test/fixtures-styles/with-include test/output --sass test/fixtures-styles/with-include/style.scss', function(err, stdout, stderr) {
-				console.log(stdout);
 				assert.ok(/Error during generation/g.test(stdout));
 				assert.ok(/error: file to import not found or unreadable: "buttons"/g.test(stdout));
 				done();


### PR DESCRIPTION
Fix for https://github.com/kss-node/kss-node/pull/103
Added test for directory "helpers"
