### PR TITLE
Custom handlebar helpers

### DIFF
--- a/bin/kss-node
+++ b/bin/kss-node
@@ -490,6 +490,9 @@ handlebars.registerHelper('html', function(arg) {
 /**
  * Load custom Handlebars helpers
  */
+if (argv.helpers) {
+    config.helpersDirectory = path.resolve(argv.helpers);
+}
 if (fs.existsSync('helpers')) {
     // Load custom Handlebars helpers
     var helperFiles = fs.readdirSync('helpers');


### PR DESCRIPTION
Based on https://github.com/kss-node/kss-node/pull/104 and https://github.com/kss-node/kss-node/pull/101

This PR adds ability to also specify custom directory because the default path defined in the PR's above was not working for the external styleguide setup I had running locally.

Steps to test:

Create a /helpers directory in your styleguide directory.

Place following test handlebars helper in a file link.js  (helpers/link.js):

```
module.exports.register = function (handlebars, options)  {
    handlebars.registerHelper('link', function(text, url) {
        return new handlebars.SafeString(
            "<a href='" + url + "'>" + text + "</a>"
        );
    });
};
```

Run this command from styleguide directory:

../node_modules/.bin/kss-node <sourcedir> <destdir> --helpers helpers
