### PR TITLE
Handlebars helpers

### DIFF
--- a/bin/kss-node
+++ b/bin/kss-node
@@ -65,7 +65,7 @@ argv = yargs
 
 	.string('S')
 	.alias('S', 'sass')
-	.describe('S', 'Compile and include a SASS stylesheet')
+	.describe('S', 'Compile and include a Sass stylesheet')
 
 	.string('y')
 	.alias('y', 'stylus')


### PR DESCRIPTION
_Original request from #101:_

Custom Handlebar helpers is a handy way of customizing the kss-node output.

It would be nice if there was some simple built-in way of loading these, like placing files in a given folder

It could be something like the attached pull request, that would read files from a "helpers" directory, given that they were written something like this:

**helpers/foo.js**

```
module.exports.register = function(handlebars) {
  handlebars.registerHelper('foo', function(arg1, arg2, options) {
    return new handlebars.SafeString('<a href="' + arg1 + '">' + arg2 + '</a>');
  });
};
```

---

This PR is a combination of #101, #104, and #107 with proper commit credit.

Also, this still needs works. The directory is hard-coded as "helpers" in a couple places.

I'll finish this up tomorrow.
