### PR TITLE
Adds ability to show modifier markup and example

### DIFF
--- a/bin/kss-node
+++ b/bin/kss-node
@@ -533,15 +533,11 @@ handlebars.registerHelper('modifierMarkup', function(modifier) {
 
 	// Maybe it's actually a section?
 	if (modifier.modifiers) {
-		return new handlebars.SafeString(
-			modifier.markup
-		);
+		return modifier.markup
 	}
 
 	// Otherwise return the modifier markup
-	return new handlebars.SafeString(
-		new kss.KssModifier(modifier).markup()
-	);
+	return new kss.KssModifier(modifier).markup();
 });
 
 /**

--- a/lib/template/index.html
+++ b/lib/template/index.html
@@ -72,7 +72,7 @@
             <td class="kss-mod-name"></td>
           </tr>
           <tr class="kss-mod-example">
-            <td colspan="2">{{modifierMarkup}}</td>
+            <td colspan="2">{{{modifierMarkup}}}</td>
           </tr>
         {{#eachModifier}}
           <tr class="kss-mod-desc-group">
@@ -80,7 +80,7 @@
             <td class="kss-mod-name"><p>{{name}}</p></td>
           </tr>
           <tr class="kss-mod-example">
-            <td colspan="2">{{modifierMarkup}}</td>
+            <td colspan="2">{{{modifierMarkup}}}</td>
           </tr>
         {{/eachModifier}}
         </table>

--- a/test/fixtures-styles/template/index.html
+++ b/test/fixtures-styles/template/index.html
@@ -55,7 +55,7 @@
 <div id="kss-test--modifierMarkup">
 {{#section "2.1.3"}}
   {{#eachModifier}}
-    {{modifierMarkup}}
+    {{{modifierMarkup}}}
   {{/eachModifier}}
 {{/section}}
 </div>

--- a/test/kss-node.js
+++ b/test/kss-node.js
@@ -110,7 +110,7 @@ suite('Command Line Interface', function() {
 				done();
 			});
 		});
-		test('Should load Handlerbars helper: {{modifierMarkup}}', function(done) {
+		test('Should load Handlerbars helper: {{{modifierMarkup}}}', function(done) {
 			exec('cat test/output/section-2.html', function(err, stdout, stderr) {
 				assert.ok(/Handlebars modifierMarkup Helper: pseudo\-class\-hover/g.test(stdout));
 				assert.ok(/Handlebars modifierMarkup Helper: stars\-given</g.test(stdout));


### PR DESCRIPTION
By escaping the modifier markup in the template, it’s possible to show both the example, and a more contextual code sample. That way, the templates can show this:

``` css
<div class="button button--large">Submit</div>
```

Instead of this:

``` css
<div class="button {$modifiers}">Submit</div>
```

I find this helpful for removing some confusion around `{$modifiers}`, and for providing the specific markup for each modifier. Let me know what you think!
