### PR TITLE
Handle combined pseudo-class modifiers.

### DIFF
--- a/lib/kss.js
+++ b/lib/kss.js
@@ -285,7 +285,7 @@ createModifiers = function(lines, options) {
 		modifier = entry.split(/\s+\-\s+/, 1)[0];
 		description = entry.replace(modifier, '', 1).replace(/^\s+\-\s+/, '');
 
-		className = modifier.replace(/\:/, '.pseudo-class-');
+		className = modifier.replace(/\:/g, '.pseudo-class-');
 
 		// Markdown parsing.
 		if (options.markdown) {

--- a/test/fixtures-styles/sections-description.less
+++ b/test/fixtures-styles/sections-description.less
@@ -6,6 +6,7 @@
 // 
 // :hover - HOVER
 // :disabled - DISABLED
+// :focus:hover - FOCUS AND HOVER
 // 
 // Styleguide 3.2.2
 

--- a/test/kss.js
+++ b/test/kss.js
@@ -250,9 +250,9 @@ suite('#traverse', function() {
 							currentData;
 
 						for (i = 0; i < l; i += 1) {
-							currentData = modifiers[i].data
+							currentData = modifiers[i].data;
 							assert.equal(
-								currentData.name.replace(/\:/, '.pseudo-class-'),
+								currentData.name.replace(/\:/g, '.pseudo-class-'),
 								currentData.className
 							);
 						}


### PR DESCRIPTION
For a modifier like `:focus:hover`, this patch will produce the classes `.pseudo-class-focus .pseudo-class-hover`. Previously it would have resulted in `.pseudo-class-focus:hover`.