### PR TITLE
Modifier section can come anywhere in the description

### DIFF
--- a/lib/kss.js
+++ b/lib/kss.js
@@ -207,6 +207,10 @@ parseChunk = function(data, input, options) {
 					// This is a named parameter
 					continue;
 				}
+				if (/^[ ]*?\$[\s\S]+[ ]+\-/.test(paragraphs[k])) {
+					// This is a parameters section
+					continue;
+				}
 				currSection.modifiers = paragraphs[k]
 					.replace(/\r\n/g, '\n')
 					.replace(/\r/g, '\n')

--- a/lib/kss.js
+++ b/lib/kss.js
@@ -200,10 +200,19 @@ parseChunk = function(data, input, options) {
 			// The modifiers will be split into an array of lines.
 			currSection.header = paragraphs[0];
 			currSection.description = paragraphs.slice(0, paragraphs.length - 2).join('\n\n');
-			currSection.modifiers = paragraphs[paragraphs.length - 2]
-				.replace(/\r\n/g, '\n')
-				.replace(/\r/g, '\n')
-				.split('\n');
+
+			// Modifiers paragraph is the last without name
+			for (var k=paragraphs.length-2;k>=0;k--) {
+				if (/[^:]*:\n/.test(paragraphs[k])) {
+					// This is a named parameter
+					continue;
+				}
+				currSection.modifiers = paragraphs[k]
+					.replace(/\r\n/g, '\n')
+					.replace(/\r/g, '\n')
+					.split('\n');
+				break;
+			}
 
 			// Check the modifiers paragraph. Does it look like it's a list of
 			// modifiers, or just another paragraph of the description?

--- a/test/fixtures-styles/sections-modifiers.less
+++ b/test/fixtures-styles/sections-modifiers.less
@@ -53,3 +53,12 @@
 // .blue   - Color - blue  -  another dash
 // 
 // Styleguide 3.1.7
+
+// SKIP CUSTOM PARAMETER
+// 
+// .green  - Color - green
+//
+// custom:
+// Custom param value
+//
+// Styleguide 3.1.8

--- a/test/kss.js
+++ b/test/kss.js
@@ -223,6 +223,11 @@ suite('#traverse', function() {
 					assert.equal(modifiers[2].data.description, 'Color - blue  -  another dash');
 				});
 
+				common.testSection('Skip custom parameter', 'sections-modifiers.less', function(section) {
+					var modifiers = section.data.modifiers;
+					assert.equal(modifiers.length, 3);
+				});
+
 				common.testSection('One line, no modifiers', 'sections-description.less', function(section) {
 					var modifiers = section.data.modifiers;
 					assert.equal(modifiers.length, 0);

--- a/test/kss.js
+++ b/test/kss.js
@@ -225,7 +225,7 @@ suite('#traverse', function() {
 
 				common.testSection('Skip custom parameter', 'sections-modifiers.less', function(section) {
 					var modifiers = section.data.modifiers;
-					assert.equal(modifiers.length, 3);
+					assert.equal(modifiers.length, 1);
 				});
 
 				common.testSection('One line, no modifiers', 'sections-description.less', function(section) {


### PR DESCRIPTION
This is a small change which does not affect the existing functionality. But it provides a possibility to have custom-named paragraphs. Now it is not possible because there is no place for them. The second last paragraph is always considered as a paragraph with modifiers. This change makes it so, that the last not named paragraph is considered to be a paragraph with modifiers. This, it can be followed with other named paragraphs with no affection onto the others.