### PR TITLE
Depend on node-sass 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "less": "^1.7.5",
     "marked": "^0.3.2",
     "natural": "^0.1.28",
-    "node-sass": "^1.2",
+    "node-sass": "2.0.0-beta",
     "stylus": "^0.48.1",
     "wrench": "^1.5.8",
     "yargs": "^1.3.1"


### PR DESCRIPTION
This fix prevents an error when installing a package on Node 0.11.x (checked with current 0.11.14 and previous 0.11.13).

Without this fix installing the package on Node 0.11.x give this error:

```
module.js:355
  Module._extensions[extension](this, filename);
                               ^
Error: Module did not self-register.
    at Error (native)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/varya/WebDev/SC5/tmp/node_modules/kss/node_modules/node-sass/lib/index.js:181:15)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
```

Unfortunately there is no stable node-sass 2.0.0 yet. But I hope they will release soon.