### PR TITLE
Fix for paths being a null object

### DIFF
--- a/bin/kss-node
+++ b/bin/kss-node
@@ -126,7 +126,7 @@ if ("init" in yargs.argv || "i" in yargs.argv) {
 if (argv.config) {
 	// Helper function to apply path.resolve() to strings or arrays of strings.
 	pathResolveRecursive = function(from, item) {
-		var paths;
+		var paths = [];
 		if (item instanceof Array) {
 			item.forEach(
 				function(value, index) {


### PR DESCRIPTION
```
node_modules/kss/bin/kss-node:136
paths[index] = path.resolve(from, value);
TypeError: Cannot set property '0' of undefined
```

``` json
{
    "source": [
        "src/stuff",
        "src/otherstuff"
    ]
}
```

This initializes the `path` array before using it.