### PR TITLE
Prevent relative path rewriting of JS and CSS paths in conifig files

### DIFF
--- a/bin/kss-node
+++ b/bin/kss-node
@@ -143,7 +143,7 @@ if (argv.config) {
 	configFile = path.resolve(argv.config);
 	config = require(configFile);
 	for (var key in config) {
-		if (config != "js" && config != "css") {
+		if (key != "js" && key != "css") {
 			argv[key] = pathResolveRecursive(path.dirname(configFile), config[key]);
 		}
 	}

--- a/bin/kss-node
+++ b/bin/kss-node
@@ -143,7 +143,9 @@ if (argv.config) {
 	configFile = path.resolve(argv.config);
 	config = require(configFile);
 	for (var key in config) {
-		argv[key] = pathResolveRecursive(path.dirname(configFile), config[key]);
+		if (config != "js" && config != "css") {
+			argv[key] = pathResolveRecursive(path.dirname(configFile), config[key]);
+		}
 	}
 }
 // Get the full source path.


### PR DESCRIPTION
Using `{{{styles}}}` and `{{{scripts}}}` with rendered HTML means that JS and CSS isn't relative. This fixes it so that they arn't resolved as such. :fish: