### PR TITLE
fixed problem with modifiernames containing a colon

### DIFF
--- a/lib/kss.js
+++ b/lib/kss.js
@@ -316,7 +316,7 @@ createModifiers = function(lines, options) {
 		modifier = entry.split(/\s+\-\s+/, 1)[0];
 		description = entry.replace(modifier, '', 1).replace(/^\s+\-\s+/, '');
 
-		className = modifier.replace(/\:/g, '.pseudo-class-');
+		className = modifier.replace(/^\:/, '.pseudo-class-');
 
 		// Markdown parsing.
 		if (options.markdown) {


### PR DESCRIPTION
Pseudo classes are always starting with a colon as the first character. But the current regex searches for any colon in the modifier name, which causes problems with modifiers that contain a colon. One example would be the following CSS rule: `[data-u-customAttr~='align:left']` where the modifier `align:left` would get falsely modified.