### PR TITLE
Clean up the npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "licence": "MIT",
   "main": "index.js",
   "scripts": {
-    "test": "echo 'Testing with mocha…' && ./node_modules/.bin/mocha -u tdd --reporter spec && echo 'Linting with eslint…' && ./node_modules/.bin/eslint . && echo '…tests done.'",
+    "test": "mocha -u tdd --reporter spec",
+    "posttest": "eslint .",
     "docs": "make docs"
   },
   "bin": {
@@ -30,6 +31,7 @@
   "devDependencies": {
     "eslint": "^0.18.0",
     "jsdoc": "^3.3.0-beta3",
+    "less": "^2.5.0",
     "mocha": "^1.21.4"
   },
   "homepage": "http://kss-node.github.io/kss-node"


### PR DESCRIPTION
A few things:

1. `npm` adds the bin directory to PATH so we don't have to prefix node_modules/.bin.
2. Rather than stringing a bunch of commands in `npm test`, we can make use of [`posttest`](https://docs.npmjs.com/misc/scripts) in the scripts. It cleans it up, and we won't have to announce that it's using mocha/eslint.
3. Noticed that `npm run docs` was missing `lessc`, so I added that in the development dependencies.