### PR TITLE
all delimiters are replaced by a dash

### DIFF
--- a/lib/kss_section.js
+++ b/lib/kss_section.js
@@ -181,7 +181,7 @@ KssSection.prototype.encodeReferenceURI = function(reference) {
   return encodeURI(
     reference
       .replace(/ \- /g, '-')
-      .replace(/[^\w-]+/, '-')
+      .replace(/[^\w-]+/g, '-')
       .toLowerCase()
   );
 };

--- a/test/test_kss_section.js
+++ b/test/test_kss_section.js
@@ -102,6 +102,14 @@ describe('KssSection object API', function() {
     });
   });
 
+  describe('.referenceURI() changes all delimiters to dashes', function() {
+    it('should return data.referenceURI', function() {
+      var section = new kss.KssSection({});
+
+      section.encodeReferenceURI('test.section.with . depth@the-end').should.be.equal('test-section-with-depth-the-end');
+    });
+  });
+
   describe('.modifiers()', function() {
     it('should return data.modifiers', function(done) {
       testUtils.eachSection(done, {mask: '*.less|*.css'}, function(section) {


### PR DESCRIPTION
Otherwise, I get CSS classes like 'button-dropdown.transparent'...

It's still *valid* CSS, but it's very annoying to deal with. ;)

Hope this can get fixed!