### PR TITLE
updated Handlebars Generator

### DIFF
--- a/generator/handlebars/kss_handlebars_generator.js
+++ b/generator/handlebars/kss_handlebars_generator.js
@@ -306,13 +306,13 @@ kssHandlebarsGenerator.generatePage = function(styleguide, sections, root, secti
   }
   // Create the HTML to load the optional CSS and JS.
   for (key in this.config.css) {
-    if(typeof this.config.destination != "undefined") {
+    if (typeof this.config.destination !== 'undefined') {
       cssPath = path.relative(this.config.destination, this.config.css[key]);
-      styles = styles + '<link rel="stylesheet" href="' + cssPath + '">\n'; 
+      styles = styles + '<link rel="stylesheet" href="' + cssPath + '">\n';
     }
   }
   for (key in this.config.js) {
-    if(typeof this.config.destination != "undefined") {
+    if (typeof this.config.destination !== 'undefined') {
       jsPath = path.relative(this.config.destination, this.config.js[key]);
       scripts = scripts + '<script src="' + jsPath + '"></script>\n';
     }

--- a/generator/handlebars/kss_handlebars_generator.js
+++ b/generator/handlebars/kss_handlebars_generator.js
@@ -302,14 +302,12 @@ kssHandlebarsGenerator.generatePage = function(styleguide, sections, root, secti
   }
   // Create the HTML to load the optional CSS and JS.
   for (key in this.config.css) {
-    if (this.config.css.hasOwnProperty(key)) {
-      styles = styles + '<link rel="stylesheet" href="' + this.config.css[key] + '">\n';
-    }
+    var cssPath = path.relative(this.config.destination,this.config.css[key]);
+    styles = styles + '<link rel="stylesheet" href="' + cssPath + '">\n';
   }
   for (key in this.config.js) {
-    if (this.config.js.hasOwnProperty(key)) {
-      scripts = scripts + '<script src="' + this.config.js[key] + '"></script>\n';
-    }
+    var jsPath = path.relative(this.config.destination, this.config.js[key]);
+    scripts = scripts + '<script src="' + jsPath + '"></script>\n';
   }
 
   /*eslint-disable key-spacing*/

--- a/generator/handlebars/kss_handlebars_generator.js
+++ b/generator/handlebars/kss_handlebars_generator.js
@@ -270,15 +270,17 @@ kssHandlebarsGenerator.generatePage = function(styleguide, sections, root, secti
       console.log(' - homepage');
     }
     // Ensure homepageText is a non-false value.
-    for (key in this.config.source) {
+    if (fs.existsSync(this.config.homepage) && typeof this.config.homepage !== "undefined") {
       if (!homepageText) {
         try {
-          files = glob.sync(this.config.source[key] + '/**/' + this.config.homepage);
+          files = glob.sync(this.config.homepage);
           if (files.length) {
             homepageText = ' ' + marked(fs.readFileSync(files[0], 'utf8'));
+            console.log("... parsing content from " + this.config.homepage);
           }
         } catch (e) {
           // empty
+          console.log("There was an error reading the content in" + this.config.homepage);
         }
       }
     }

--- a/generator/handlebars/kss_handlebars_generator.js
+++ b/generator/handlebars/kss_handlebars_generator.js
@@ -261,6 +261,8 @@ kssHandlebarsGenerator.generatePage = function(styleguide, sections, root, secti
     homepageText = false,
     styles = '',
     scripts = '',
+    cssPath = '',
+    jsPath = '',
     customFields = this.config.custom,
     key;
 
@@ -270,17 +272,17 @@ kssHandlebarsGenerator.generatePage = function(styleguide, sections, root, secti
       console.log(' - homepage');
     }
     // Ensure homepageText is a non-false value.
-    if (fs.existsSync(this.config.homepage) && typeof this.config.homepage !== "undefined") {
+    if (fs.existsSync(this.config.homepage) && typeof this.config.homepage !== 'undefined') {
       if (!homepageText) {
         try {
           files = glob.sync(this.config.homepage);
           if (files.length) {
             homepageText = ' ' + marked(fs.readFileSync(files[0], 'utf8'));
-            console.log("... parsing content from " + this.config.homepage);
+            console.log('... parsing content from ' + this.config.homepage);
           }
         } catch (e) {
           // empty
-          console.log("There was an error reading the content in" + this.config.homepage);
+          console.log('There was an error reading the content in' + this.config.homepage);
         }
       }
     }
@@ -304,12 +306,16 @@ kssHandlebarsGenerator.generatePage = function(styleguide, sections, root, secti
   }
   // Create the HTML to load the optional CSS and JS.
   for (key in this.config.css) {
-    var cssPath = path.relative(this.config.destination,this.config.css[key]);
-    styles = styles + '<link rel="stylesheet" href="' + cssPath + '">\n';
+    if(typeof this.config.destination != "undefined") {
+      cssPath = path.relative(this.config.destination, this.config.css[key]);
+      styles = styles + '<link rel="stylesheet" href="' + cssPath + '">\n'; 
+    }
   }
   for (key in this.config.js) {
-    var jsPath = path.relative(this.config.destination, this.config.js[key]);
-    scripts = scripts + '<script src="' + jsPath + '"></script>\n';
+    if(typeof this.config.destination != "undefined") {
+      jsPath = path.relative(this.config.destination, this.config.js[key]);
+      scripts = scripts + '<script src="' + jsPath + '"></script>\n';
+    }
   }
 
   /*eslint-disable key-spacing*/

--- a/generator/handlebars/kss_handlebars_generator.js
+++ b/generator/handlebars/kss_handlebars_generator.js
@@ -57,7 +57,7 @@ kssHandlebarsGenerator.init = function(config) {
 
   // Save the configuration parameters.
   this.config = config;
-
+  this.config.helpers = this.config.helpers || [];
   if (this.config.verbose) {
     console.log('');
     console.log('Generating your KSS style guide!');


### PR DESCRIPTION
There is an issue if you try to initiate the kssHandlebarsGenerator via the JS-API directly. If no custom helpers are defined the script is throwing an error because in line 109 the check this.config.helpers.length > 0 will throw an error if this.config.helpers = undefined .
This small change should fix it.