### PR TITLE
Add an atRule option

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -109,11 +109,11 @@ const parse = function(input, options) {
 
       // Before anything else, process the properties that are clearly labeled
       // and can be found right away and then removed.
-      processProperty.call(newSection, paragraphs, 'Markup');
-      processProperty.call(newSection, paragraphs, 'Weight', toFloat);
+      processProperty.call(newSection, paragraphs, options, 'Markup');
+      processProperty.call(newSection, paragraphs, options, 'Weight', toFloat);
       // Process custom properties.
       for (let customProperty of options.custom) {
-        processProperty.call(newSection, paragraphs, customProperty);
+        processProperty.call(newSection, paragraphs, options, customProperty);
       }
 
       // If the block is just a reference, copy the reference into the header.
@@ -179,8 +179,8 @@ const parse = function(input, options) {
       newSection.header = newSection.header.replace(/\n/g, ' ');
 
       // Check the section's status.
-      newSection.deprecated = hasPrefix(newSection.description, 'Deprecated');
-      newSection.experimental = hasPrefix(newSection.description, 'Experimental');
+      newSection.deprecated = hasPrefix(newSection.description, options, 'Deprecated');
+      newSection.experimental = hasPrefix(newSection.description, options, 'Experimental');
 
       // If a separate header is requested, remove the first paragraph from the
       // description.
@@ -398,18 +398,23 @@ const findReference = function(text) {
  * @private
  * @param {Array} paragraphs An array of the paragraphs in a single comment
  *   block.
+ * @param {Object} options The options object passed on from the initial functions
  * @param {String} propertyName The name of the property to search for.
  * @param {Function} [processValue] A function to massage the value before it is
  *   inserted into `this`.
  */
-const processProperty = function(paragraphs, propertyName, processValue) {
+const processProperty = function(paragraphs, options, propertyName, processValue) {
   let indexToRemove = false;
 
   propertyName = propertyName.toLowerCase();
 
   for (let i = 0; i < paragraphs.length; i++) {
-    if (hasPrefix(paragraphs[i], propertyName)) {
-      this[propertyName] = paragraphs[i].replace(new RegExp('^\\s*' + propertyName + '\\:\\s+?', 'gmi'), '');
+    if (hasPrefix(paragraphs[i], options, propertyName)) {
+      if (options.atRule) {
+        this[propertyName] = paragraphs[i].replace(new RegExp('^@\\s*' + propertyName + '\\s+?', 'gmi'), '');
+      } else {
+        this[propertyName] = paragraphs[i].replace(new RegExp('^\\s*' + propertyName + '\\:\\s+?', 'gmi'), '');
+      }
       if (typeof processValue === 'function') {
         this[propertyName] = processValue(this[propertyName]);
       }
@@ -429,10 +434,14 @@ const processProperty = function(paragraphs, propertyName, processValue) {
  *
  * @private
  * @param {String} description The string to check.
+ * @param {Object} options The options passed on from previous functions
  * @param {String} prefix The prefix to search for.
  * @returns {Boolean} Whether the description contains the specified prefix.
  */
-const hasPrefix = function(description, prefix) {
+const hasPrefix = function(description, options, prefix) {
+  if (options.atRule) {
+    return (new RegExp('^@\\s*' + prefix.toLowerCase(), 'gmi')).test(description);
+  }
   return (new RegExp('^\\s*' + prefix + '\\:', 'gmi')).test(description);
 };
 

--- a/test/fixtures/at-rules/options-custom.less
+++ b/test/fixtures/at-rules/options-custom.less
@@ -1,0 +1,36 @@
+// Custom property: inline
+//
+// Using inline comment syntax.
+//
+// @custom The value of this property is inline.
+//
+// Style guide: custom.inline
+
+// Custom property: next line
+//
+// Using inline comment syntax.
+//
+// @custom
+// The value of this property is on the next line.
+//
+// Style guide: custom.value.next-line
+
+// Custom property: multi-line
+//
+// Using inline comment syntax.
+//
+// @custom
+// The value of this property spans multiple
+// lines.
+//
+// Style guide: custom.value.multi-line
+
+// Custom property: multiple properties
+//
+// Using inline comment syntax.
+//
+// @custom This is the first property.
+//
+// @custom2 This is the second property.
+//
+// Style guide: custom.multi

--- a/test/fixtures/at-rules/property-deprecated-experimental.less
+++ b/test/fixtures/at-rules/property-deprecated-experimental.less
@@ -1,0 +1,39 @@
+// @deprecated In Header
+//
+// Style guide: deprecated.in-header
+
+// In Paragraph (deprecated)
+//
+// @deprecated Yup
+//
+// Style guide: deprecated.in-paragraph
+
+// In Modifiers (deprecated)
+//
+// :hover - @deprecated nope
+//
+// Style guide: deprecated.in-modifier
+
+// Not at the beginning, @deprecated nope
+//
+// Style guide: deprecated.not-at-beginning
+
+// @experimental In Header
+//
+// Style guide: experimental.in-header
+
+// In Paragraph (experimental)
+//
+// @experimental Yup
+//
+// Style guide: experimental.in-paragraph
+
+// In Modifiers (experimental)
+//
+// :hover - @experimental nope
+//
+// Style guide: experimental.in-modifier
+
+// Not at the beginning, @experimental nope
+//
+// Style guide: experimental.not-at-beginning

--- a/test/test_parse.js
+++ b/test/test_parse.js
@@ -310,6 +310,43 @@ describe('kss.parse()', function() {
         });
       });
 
+      describe('.deprecated/.experimental with at-rule', function() {
+        before(function() {
+          return helperUtils.traverseFixtures({
+            mask: 'at-rules/property-deprecated-experimental.less',
+            markdown: false,
+            header: true,
+            atRule: true
+          }).then(styleGuide => {
+            this.styleGuide = styleGuide;
+          });
+        });
+
+        it('should find in header', function(done) {
+          expect(this.styleGuide.sections('deprecated.in-header').deprecated()).to.be.true;
+          expect(this.styleGuide.sections('experimental.in-header').experimental()).to.be.true;
+          done();
+        });
+
+        it('should find in description', function(done) {
+          expect(this.styleGuide.sections('deprecated.in-paragraph').deprecated()).to.be.true;
+          expect(this.styleGuide.sections('experimental.in-paragraph').experimental()).to.be.true;
+          done();
+        });
+
+        it('should not find in modifiers', function(done) {
+          expect(this.styleGuide.sections('deprecated.in-modifier').deprecated()).to.be.false;
+          expect(this.styleGuide.sections('experimental.in-modifier').experimental()).to.be.false;
+          done();
+        });
+
+        it('should not find when not at the beginning of a line', function(done) {
+          expect(this.styleGuide.sections('deprecated.not-at-beginning').deprecated()).to.be.false;
+          expect(this.styleGuide.sections('experimental.not-at-beginning').experimental()).to.be.false;
+          done();
+        });
+      });
+
       describe('.reference', function() {
         it('should find reference "X.0" without trailing zero', function() {
           return helperUtils.traverseFixtures({mask: 'sections-queries.less', header: true}).then(styleGuide => {
@@ -357,6 +394,40 @@ describe('kss.parse()', function() {
 
       it('should find a multi-word property', function(done) {
         expect(this.styleGuide.sections('custom.multi-word').custom('custom multi-word property')).to.equal('This is a multi-word property.');
+        done();
+      });
+
+      it('should find multiple properties', function(done) {
+        expect(this.styleGuide.sections('custom.multi').custom('custom')).to.equal('This is the first property.');
+        expect(this.styleGuide.sections('custom.multi').custom('custom2')).to.equal('This is the second property.');
+        done();
+      });
+    });
+
+    describe('.custom with at-rule', function() {
+      before(function() {
+        return helperUtils.traverseFixtures({
+          mask: 'at-rules/options-custom.less',
+          markdown: false,
+          custom: ['custom', 'custom2'],
+          atRule: true
+        }).then(styleGuide => {
+          this.styleGuide = styleGuide;
+        });
+      });
+
+      it('should find an inline value', function(done) {
+        expect(this.styleGuide.sections('custom.inline').custom('custom')).to.equal('The value of this property is inline.');
+        done();
+      });
+
+      it('should find a value on the next line', function(done) {
+        expect(this.styleGuide.sections('custom.value.next-line').custom('custom')).to.equal('The value of this property is on the next line.');
+        done();
+      });
+
+      it('should find a multi-line value', function(done) {
+        expect(this.styleGuide.sections('custom.value.multi-line').custom('custom')).to.equal('The value of this property spans multiple\nlines.');
         done();
       });
 

--- a/test/test_traverse.js
+++ b/test/test_traverse.js
@@ -6,7 +6,7 @@ describe('kss.traverse()', function() {
   describe('API validation checks', function() {
     it('should function without options', function() {
       return kss.traverse(helperUtils.fixtures()).then(styleGuide => {
-        expect(styleGuide.meta.files).to.have.length(23);
+        expect(styleGuide.meta.files).to.have.length(25);
       }, error => {
         expect(error).to.not.exist;
       });
@@ -14,7 +14,7 @@ describe('kss.traverse()', function() {
 
     it('should function with options', function() {
       return kss.traverse(helperUtils.fixtures(), {}).then(styleGuide => {
-        expect(styleGuide.meta.files).to.have.length(23);
+        expect(styleGuide.meta.files).to.have.length(25);
       }, error => {
         expect(error).to.not.exist;
       });


### PR DESCRIPTION
I've noticed that docblocks are also supported in kss-node so I have a plan to use kss-node as if I'm writing a JSDoc. Here's an at-rule feature that I'm making for my own use, so I was wondering if this is also welcomed upstream.

Changes include passing the `options` parameter again to `hasPrefix` and `processProperty`, supporting the `@deprecated` and `@experimental` as well as the custom properties set, and the appropriate tests. Do let me know if there's additional refactoring necessary to be done.