### PR TITLE
Cross-platform path separators

### DIFF
--- a/builder/base/handlebars/kss_builder_base_handlebars.js
+++ b/builder/base/handlebars/kss_builder_base_handlebars.js
@@ -116,7 +116,7 @@ class KssBuilderBaseHandlebars extends KssBuilderBase {
                 // Only look at the part of the path inside the builder.
                 let relativePath = path.sep + path.relative(this.options.builder, filePath);
                 // Skip any files with a path matching: /node_modules or /.
-                return (new RegExp('^(?!.*' + path.sep + '(node_modules$|\\.))')).test(relativePath);
+                return (new RegExp('^(?!.*\\' + path.sep + '(node_modules$|\\.))')).test(relativePath);
               }
             }
           ).catch(() => {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -95,7 +95,7 @@ const parse = function(input, options) {
         }
       };
       if (file.base) {
-        newSection.sourceFile.name = path.relative(file.base, file.path);
+        newSection.sourceFile.name = path.relative(file.base, file.path).replace(/\\/g, '/');
       }
 
       // Split the comment block into paragraphs.


### PR DESCRIPTION
The latest HEAD version fails to build KSS on Windows. After some investigation I've noticed that WIN path separator works like escape symbol unless escaped. So I've escaped the path.sep. 

Also I think that paths in the generated .html files always should be in UNIX-like style. Our team works on Windows, OSX and Ubuntu and it would be painful to see commits just with slashes changed.

Tested on Windows and OSX.