### PR TITLE
Fix opts.stderr.write not being a function

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -111,8 +111,15 @@ const cli = function(opts) {
   // Set up an error handler for Promised tasks in this module; kss() will
   // handle its own errors, so we don't want to double-catch/report its errors.
   const reportError = function(error) {
-    // Show the full error stack if the verbose option is used twice or more.
-    opts.stderr.write(((error.stack && options.verbose > 1) ? error.stack : error) + '\n');
+    // Make sure the standard error handler is writable.
+    if (opts && opts.stderr && opts.stderr.write) {
+      // Show the full error stack if the verbose option is used twice or more.
+      opts.stderr.write(((error.stack && options.verbose > 1) ? error.stack : error) + '\n');
+    }
+    else {
+      // If the standard output for errors is not there, use console.error().
+      console.error(error);
+    }
   };
 
   // Confirm this is a compatible builder.


### PR DESCRIPTION
When stderr is not there, use console.error.