### PR TITLE
Scrollspy error occurred when trying to find ID of element.

### DIFF
--- a/builder/handlebars/index.hbs
+++ b/builder/handlebars/index.hbs
@@ -35,7 +35,7 @@
             <ul class="kss-nav__menu-child">
             {{#each children}}
               <li class="kss-nav__menu-item">
-                <a class="kss-nav__menu-link" href="section-{{../referenceURI}}.html#kssref-{{referenceURI}}">
+                <a class="kss-nav__menu-link" href="section-{{../referenceURI}}.html#kss-fullscreen-{{referenceURI}}">
                   <span class="kss-nav__ref {{#if isGrandChild}}kss-nav__ref-child{{/if}}">{{referenceNumber}}</span
                   ><span class="kss-nav__name">{{header}}</span>
                 </a>

--- a/builder/twig/index.twig
+++ b/builder/twig/index.twig
@@ -34,7 +34,7 @@
           <ul class="kss-nav__menu-child">
           {% for menu_child in menu_item.children %}
             <li class="kss-nav__menu-item">
-              <a class="kss-nav__menu-link" href="section-{{ menu_item.referenceURI }}.html#kssref-{{ menu_child.referenceURI }}">
+              <a class="kss-nav__menu-link" href="section-{{ menu_item.referenceURI }}.html#kss-fullscreen-{{ menu_child.referenceURI }}">
                 <span class="kss-nav__ref {% if menu_child.isGrandChild %}kss-nav__ref-child{% endif %}">{{ menu_child.referenceNumber }}</span
                 ><span class="kss-nav__name">{{ menu_child.header }}</span>
               </a>


### PR DESCRIPTION
#362 The Addition of the fullscreen feature changed the classname from kssref-* to kss-fullscreen-*. This caused scrollspy to error when trying to track the href and ID's