### PR TITLE
Remove the success message

### DIFF
--- a/gh-pages/api/master/internals/lib_kss.js.html
+++ b/gh-pages/api/master/internals/lib_kss.js.html
@@ -19,11 +19,11 @@
 
     <h1 class="page-title">Source: lib/kss.js</h1>
 
-    
 
 
 
-    
+
+
     <section>
         <article>
             <pre class="prettyprint source linenums"><code>'use strict';
@@ -179,9 +179,8 @@ const kss = function(options) {
       return builder.build(styleGuide);
     }).then(styleGuide => {
       if (builder.getOptions('verbose')) {
-        builder.log('');
+        builder.log('Style guide build completed successfully!');
       }
-      builder.log('Style guide build completed successfully!');
       return Promise.resolve(styleGuide);
     });
   }).catch(error => {

--- a/gh-pages/api/master/lib_kss.js.html
+++ b/gh-pages/api/master/lib_kss.js.html
@@ -19,11 +19,11 @@
 
     <h1 class="page-title">Source: lib/kss.js</h1>
 
-    
 
 
 
-    
+
+
     <section>
         <article>
             <pre class="prettyprint source linenums"><code>'use strict';
@@ -179,9 +179,8 @@ const kss = function(options) {
       return builder.build(styleGuide);
     }).then(styleGuide => {
       if (builder.getOptions('verbose')) {
-        builder.log('');
+        builder.log('Style guide build completed successfully!');
       }
-      builder.log('Style guide build completed successfully!');
       return Promise.resolve(styleGuide);
     });
   }).catch(error => {

--- a/lib/kss.js
+++ b/lib/kss.js
@@ -151,9 +151,8 @@ const kss = function(options) {
       return builder.build(styleGuide);
     }).then(styleGuide => {
       if (builder.getOptions('verbose')) {
-        builder.log('');
+        builder.log('Style guide build completed successfully!');
       }
-      builder.log('Style guide build completed successfully!');
       return Promise.resolve(styleGuide);
     });
   }).catch(error => {

--- a/test/fixtures/cli-option-config-source-array.json
+++ b/test/fixtures/cli-option-config-source-array.json
@@ -2,5 +2,6 @@
   "//"          : "A JSON comment",
   "source"      : ["with-include", "missing-homepage"],
   "destination" : "../output/nested",
-  "builder"     : "builder"
+  "builder"     : "builder",
+  "verbose"     : true
 }

--- a/test/test_kss.js
+++ b/test/test_kss.js
@@ -133,7 +133,8 @@ describe('kss object API', function() {
       it('should warn if homepage content is not found', function() {
         return testKss({
           source: helperUtils.fixtures('missing-homepage'),
-          destination: 'test/output/nested'
+          destination: 'test/output/nested',
+          verbose: true
         }).then(function(result) {
           expect(result.error).to.not.exist;
           expect(result.stdout).to.include(noHomepageWarning);


### PR DESCRIPTION
Adopt the "No News is Good News" philosophy, where only errors/warnings are reports. You can still optionally have the success message display by using `--verbose`.