### PR TITLE
Pseudo class generation

### DIFF
--- a/builder/handlebars/kss-assets/kss.js
+++ b/builder/handlebars/kss-assets/kss.js
@@ -19,10 +19,16 @@
             for (idx = 0, _len2 = _ref2.length; idx < _len2; idx++) {
               rule = _ref2[idx];
               if ((rule.type === CSSRule.STYLE_RULE) && pseudos.test(rule.selectorText)) {
-                replaceRule = function(matched, stuff) {
-                  return matched.replace(/\:/g, '.pseudo-class-');
-                };
-                this.insertRule(rule.cssText.replace(pseudos, replaceRule));
+                selectorRules = rule.selectorText.split(',');
+                for(idx2 = 0, amountOfRules = selectorRules.length; idx2 < amountOfRules; idx2++) {
+                  var selector = selectorRules[idx2];
+                  if(pseudos.test(selector)) {
+                    replaceRule = function(matched, stuff) {
+                        return matched.replace(/\:/g, '.pseudo-class-');
+                    };
+                    this.insertRule(selector.replace(pseudos, replaceRule) + ' { ' + rule.style.cssText + ' } ' );
+                  }
+                }
               }
               pseudos.lastIndex = 0;
             }


### PR DESCRIPTION
This PR will add an extra check in the generation of pseudo classes. Currently the whole css rule is copied and replaced with the ".pseudo-class-" prefix and as inline-style inserted in the page. 

In my case this was not desirable because some of my css selectors have comma's in them. Which resulted in that the selectors where overridden with the inline styles. Which should not be the case. 

This PR fixes that, an extra check if there are comma's in the selector. And only replaces the selectors which are needed to be replaced. 

Besides this, this code needs a little bit more love. I can do that but for now this fixes my problem. 