### PR TITLE
Allow to place "Styleguide" property anywhere

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -107,7 +107,7 @@ const parse = function(input, options) {
           paragraphs.splice(i, 1);
         }
       }
-      
+
       if (!newSection.reference) {
         continue;
       }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -100,7 +100,14 @@ const parse = function(input, options) {
       let paragraphs = comment.text.split('\n\n');
 
       // Ignore this block if a style guide reference number is not listed.
-      newSection.reference = findReference(paragraphs.pop());
+      for (let i = 0; i < paragraphs.length; i++) {
+        let reference = findReference(paragraphs[i]);
+        if (reference) {
+          newSection.reference = reference;
+          paragraphs.splice(i, 1);
+        }
+      }
+      
       if (!newSection.reference) {
         continue;
       }


### PR DESCRIPTION
Is the 'styleguide' property really required to be the last property of the documentation?

On my case, I need to place a custom property as last property of documentation. Without this fix, the sections with this custom property are not passed as sections on the styleguide object and are not rendered.

I propose this solution to fix the issue.