### PR TITLE
Add Emoji Support

### DIFF
--- a/builder/base/kss_builder_base.js
+++ b/builder/base/kss_builder_base.js
@@ -13,6 +13,7 @@
    *************************************************************** */
 
 const marked = require('marked'),
+  emoji = require('node-emoji'),
   path = require('path'),
   Promise = require('bluebird');
 
@@ -146,7 +147,13 @@ class KssBuilderBase {
         describe: 'Limit the navigation to the depth specified',
         default: 3
       },
-
+      'emoji': {
+        group: 'Style guide:',
+        boolean: true,
+        multiple: false,
+        describe: 'Add emoji support',
+        default: true
+      },
       'verbose': {
         count: true,
         multiple: false,
@@ -1143,6 +1150,9 @@ class KssBuilderBase {
           // Ensure homePageText is a non-false value. And run any results through
           // Markdown.
           context.homepage = homePageText ? marked(homePageText) : '';
+          if (this.options.emoji) {
+            context.homepage = emoji.emojify(context.homepage);
+          }
           return Promise.resolve();
         });
       }

--- a/lib/kss.js
+++ b/lib/kss.js
@@ -137,7 +137,8 @@ const kss = function(options) {
         markdown: true,
         markup: true,
         mask: builder.getOptions('mask'),
-        custom: builder.getOptions('custom')
+        custom: builder.getOptions('custom'),
+        emoji: builder.getOptions('emoji')
       });
     }
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -12,6 +12,7 @@
  */
 
 const KssStyleGuide = require('./kss_style_guide.js'),
+  emoji = require('node-emoji'),
   marked = require('marked'),
   path = require('path');
 
@@ -43,6 +44,9 @@ const parse = function(input, options) {
   }
   if (typeof options.header === 'undefined') {
     options.header = true;
+  }
+  if (typeof options.emoji === 'undefined') {
+    options.emoji = true;
   }
   options.custom = options.custom || [];
 
@@ -197,6 +201,12 @@ const parse = function(input, options) {
         }
       }
 
+      // Emoji parsing
+      if (options.emoji) {
+        newSection.header = emoji.emojify(newSection.header);
+        newSection.description = emoji.emojify(newSection.description);
+      }
+
       // Markdown Parsing.
       if (options.markdown) {
         newSection.description = marked(newSection.description);
@@ -336,6 +346,11 @@ const createModifiers = function(rawModifiers, options) {
     let modifier = entry.split(/\s+\-\s+/, 1)[0];
     let description = entry.replace(modifier, '', 1).replace(/^\s+\-\s+/, '');
 
+    // Emoji parsing
+    if (options.emoji) {
+      description = emoji.emojify(description);
+    }
+
     // Markdown parsing.
     if (options.markdown) {
       description = marked(description, {renderer: inlineRenderer});
@@ -369,6 +384,11 @@ const createParameters = function(rawParameters, options) {
       let tokens = parameter.split(/\s+=\s+/);
       parameter = tokens[0];
       defaultValue = tokens[1];
+    }
+
+    // Emoji parsing
+    if (options.emoji) {
+      description = emoji.emojify(description);
     }
 
     // Markdown parsing.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "glob": "^7.0.3",
     "handlebars": "^4.0.0",
     "marked": "^0.3.6",
+    "node-emoji": "^1.8.1",
     "nunjucks": "^3.0.1",
     "twig": "^1.10.4",
     "twig-drupal-filters": "^1.0.0",

--- a/test/fixtures/options-emoji.less
+++ b/test/fixtures/options-emoji.less
@@ -1,0 +1,9 @@
+// HEADER :smile:
+//
+// DESCRIPTION :smile:
+//
+// Markup: <div>
+//
+// :hover - HOVER :smile:
+//
+// Style guide: emoji

--- a/test/test_kss_builder_base.js
+++ b/test/test_kss_builder_base.js
@@ -132,7 +132,7 @@ describe('KssBuilderBase object API', function() {
 
     it('should implement the default option definitions', function() {
       let builder = new KssBuilderBase();
-      expect(Object.getOwnPropertyNames(builder.optionDefinitions)).to.deep.equal(['source', 'destination', 'json', 'mask', 'clone', 'builder', 'css', 'js', 'custom', 'extend', 'homepage', 'markup', 'placeholder', 'nav-depth', 'verbose']);
+      expect(Object.getOwnPropertyNames(builder.optionDefinitions)).to.deep.equal(['source', 'destination', 'json', 'mask', 'clone', 'builder', 'css', 'js', 'custom', 'extend', 'homepage', 'markup', 'placeholder', 'nav-depth', 'emoji', 'verbose']);
     });
 
     it('should set the default log function', function() {
@@ -770,7 +770,8 @@ describe('KssBuilderBase object API', function() {
         source: helperUtils.fixtures('source-handlebars-builder-test'),
         destination: path.resolve(__dirname, 'output', 'base_handlebars', 'build-no-verbose'),
         builder: helperUtils.fixtures('builder-with-assets'),
-        extend: helperUtils.fixtures('builder-with-assets', 'extend')
+        extend: helperUtils.fixtures('builder-with-assets', 'extend'),
+        emoji: false
       });
       let styleGuide = new kss.KssStyleGuide({sections: [{header: 'Heading 4.3', reference: '4.3', markup: '4.3.hbs'}]});
       return builder.prepare(styleGuide).then(styleGuide => {

--- a/test/test_kss_builder_base_example.js
+++ b/test/test_kss_builder_base_example.js
@@ -66,7 +66,7 @@ describe('KssBuilderBaseExample object API', function() {
 
     it('should implement the default option definitions', function() {
       let builder = new KssBuilderBaseExample();
-      expect(Object.getOwnPropertyNames(builder.optionDefinitions)).to.deep.equal(['source', 'destination', 'json', 'mask', 'clone', 'builder', 'css', 'js', 'custom', 'extend', 'homepage', 'markup', 'placeholder', 'nav-depth', 'verbose', 'example-option']);
+      expect(Object.getOwnPropertyNames(builder.optionDefinitions)).to.deep.equal(['source', 'destination', 'json', 'mask', 'clone', 'builder', 'css', 'js', 'custom', 'extend', 'homepage', 'markup', 'placeholder', 'nav-depth', 'emoji', 'verbose', 'example-option']);
     });
   });
 

--- a/test/test_kss_builder_base_handlebars.js
+++ b/test/test_kss_builder_base_handlebars.js
@@ -101,7 +101,7 @@ describe('KssBuilderBaseHandlebars object API', function() {
 
     it('should implement the default option definitions', function() {
       let builder = new KssBuilderBaseHandlebars();
-      expect(Object.getOwnPropertyNames(builder.optionDefinitions)).to.deep.equal(['source', 'destination', 'json', 'mask', 'clone', 'builder', 'css', 'js', 'custom', 'extend', 'homepage', 'markup', 'placeholder', 'nav-depth', 'verbose']);
+      expect(Object.getOwnPropertyNames(builder.optionDefinitions)).to.deep.equal(['source', 'destination', 'json', 'mask', 'clone', 'builder', 'css', 'js', 'custom', 'extend', 'homepage', 'markup', 'placeholder', 'nav-depth', 'emoji', 'verbose']);
     });
   });
 

--- a/test/test_kss_builder_base_nunjucks.js
+++ b/test/test_kss_builder_base_nunjucks.js
@@ -101,7 +101,7 @@ describe('KssBuilderBaseNunjucks object API', function() {
 
     it('should implement the default option definitions', function() {
       let builder = new KssBuilderBaseNunjucks();
-      expect(Object.getOwnPropertyNames(builder.optionDefinitions)).to.deep.equal(['source', 'destination', 'json', 'mask', 'clone', 'builder', 'css', 'js', 'custom', 'extend', 'homepage', 'markup', 'placeholder', 'nav-depth', 'verbose', 'extension']);
+      expect(Object.getOwnPropertyNames(builder.optionDefinitions)).to.deep.equal(['source', 'destination', 'json', 'mask', 'clone', 'builder', 'css', 'js', 'custom', 'extend', 'homepage', 'markup', 'placeholder', 'nav-depth', 'emoji', 'verbose', 'extension']);
     });
   });
 

--- a/test/test_kss_builder_base_twig.js
+++ b/test/test_kss_builder_base_twig.js
@@ -113,7 +113,7 @@ describe('KssBuilderBaseTwig object API', function() {
 
     it('should implement the default option definitions', function() {
       let builder = new KssBuilderBaseTwig();
-      expect(Object.getOwnPropertyNames(builder.optionDefinitions)).to.deep.equal(['source', 'destination', 'json', 'mask', 'clone', 'builder', 'css', 'js', 'custom', 'extend', 'homepage', 'markup', 'placeholder', 'nav-depth', 'verbose', 'extend-drupal8', 'namespace']);
+      expect(Object.getOwnPropertyNames(builder.optionDefinitions)).to.deep.equal(['source', 'destination', 'json', 'mask', 'clone', 'builder', 'css', 'js', 'custom', 'extend', 'homepage', 'markup', 'placeholder', 'nav-depth', 'emoji', 'verbose', 'extend-drupal8', 'namespace']);
     });
   });
 

--- a/test/test_parse.js
+++ b/test/test_parse.js
@@ -182,7 +182,7 @@ describe('kss.parse()', function() {
 
       describe('.modifiers', function() {
         before(function() {
-          return helperUtils.traverseFixtures({mask: 'property-modifiers.less', markdown: false}).then(styleGuide => {
+          return helperUtils.traverseFixtures({mask: 'property-modifiers.less', markdown: false, emoji: false}).then(styleGuide => {
             this.styleGuide = styleGuide;
           });
         });
@@ -280,7 +280,7 @@ describe('kss.parse()', function() {
 
       describe('.deprecated/.experimental', function() {
         before(function() {
-          return helperUtils.traverseFixtures({mask: 'property-deprecated-experimental.less', markdown: false, header: true}).then(styleGuide => {
+          return helperUtils.traverseFixtures({mask: 'property-deprecated-experimental.less', markdown: false, header: true, emoji: false}).then(styleGuide => {
             this.styleGuide = styleGuide;
           });
         });

--- a/test/test_parse.js
+++ b/test/test_parse.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const marked = require('marked');
+const emoji = require('node-emoji');
 
 describe('kss.parse()', function() {
   before(function(done) {
@@ -407,6 +408,34 @@ describe('kss.parse()', function() {
       it('should not add HTML when disabled', function() {
         return helperUtils.traverseFixtures({mask: 'property-header.less', markdown: false}).then(styleGuide => {
           expect(styleGuide.sections('header.three-paragraphs').description()).to.equal('ANOTHER PARAGRAPH\n\nAND ANOTHER');
+        });
+      });
+    });
+
+    describe('.emoji:', function() {
+      it('should be enabled by default', function() {
+        return helperUtils.traverseFixtures({
+          mask: 'options-emoji.less',
+          markdown: false
+        }).then(styleGuide => {
+          let section = styleGuide.sections('emoji');
+          let modifiers = section.modifiers();
+          expect(section.header()).to.equal(emoji.emojify('HEADER :smile:'));
+          expect(section.description()).to.equal(emoji.emojify('DESCRIPTION :smile:'));
+          expect(modifiers[0].description()).to.equal(emoji.emojify('HOVER :smile:'));
+        });
+      });
+      it('should not add emoji when disabled', function() {
+        return helperUtils.traverseFixtures({
+          mask: 'options-emoji.less',
+          markdown: false,
+          emoji: false
+        }).then(styleGuide => {
+          let section = styleGuide.sections('emoji');
+          let modifiers = section.modifiers();
+          expect(section.header()).to.equal('HEADER :smile:');
+          expect(section.description()).to.equal('DESCRIPTION :smile:');
+          expect(modifiers[0].description()).to.equal('HOVER :smile:');
         });
       });
     });


### PR DESCRIPTION
Emoji's are critical to all aspects of life especially style guides.  This pull request will add emoji support (enabled by default) to KSS Node.  Passing in `--emoji false` will disable them, though I can't image a world where you would want to do that 🤔 .

- Add [`node-emoji`](https://www.npmjs.com/package/node-emoji) dependency
- Add disable option
- Ensure existing tests pass
- Ensure 100% coverage