### PR TITLE
Fail when a markup file is missing

### DIFF
--- a/builder/base/kss_builder_base.js
+++ b/builder/base/kss_builder_base.js
@@ -887,15 +887,10 @@ class KssBuilderBase {
               }
             }
 
-            // If the markup file is not found, note that in the style guide.
+            // If the markup file is not found, fail.
             if (!foundTemplate && !foundExample) {
               template.markup += ' NOT FOUND!';
-              if (!this.options.verbose) {
-                this.log('WARNING: In section ' + template.reference + ', ' + template.markup);
-              }
-              loadTemplates.push(
-                loadInlineTemplate(template.name, template.markup)
-              );
+              throw new Error('ERROR: In section ' + template.reference + ', ' + template.markup);
             } else if (!foundTemplate) {
               // If we found an example, but no template, load an empty
               // template.


### PR DESCRIPTION
Thanks for a great library! We have been using for about a year now to:

- coordinate with non-developers
- generate unit tests (using the `Markup:` HTML markup files) and code coverage of our CSS files (using [css-coverage](https://www.npmjs.com/package/css-coverage)

`kss` currently outputs a warning message when a Markup file is missing but still gives a `0` exit status. In scripts and CI systems like Travis it would be nice to fail whenever those files are missing.

Example use case: for every commit, [we](https://openstax.org/about) generate a style guide and host it for people to review.

To see an example, click any of the green check marks ✅  next to [any commit here](https://github.com/Connexions/cnx-recipes/commits/master).


If this change (or something similar) would be useful to others I can work fixing up the unit tests.