### PR TITLE
Add ability to scan directories matching a wildcard string

### DIFF
--- a/lib/traverse.js
+++ b/lib/traverse.js
@@ -17,6 +17,8 @@ const parse = require('./parse.js'),
 
 const fs = Promise.promisifyAll(require('fs-extra'));
 
+const glob = require("glob");
+
 /**
  * Traverse a directory, parse its contents, and create a KssStyleGuide.
  *
@@ -70,9 +72,40 @@ let traverse = function(directories, options) {
     directories = [directories];
   }
 
+  // Find any strings in the directories array with the wildcard string.
+  let wildcardStrings = [];
+  directories.forEach((val, index) => {
+    if (val.indexOf('*') > -1) {
+      wildcardStrings.push(val);
+    }
+  });
+
+  // Use the glob module to scan for directories that match the wildcard string.
+  let tempDirectories = [];
+  wildcardStrings.forEach((val, index) => {
+    let globResult = glob.sync(val);
+    // Only concat the arrays if they have values.
+    if (globResult.length > 0) {
+      tempDirectories = tempDirectories.concat(globResult);      
+    }
+  });
+
+  // Add found directories to the directories array.
+  directories = directories.concat(tempDirectories);
+
+  // Remove any wildcard strings from the array.
+  wildcardStrings.forEach((val, index) => {
+    let wildCardStringindex = directories.indexOf(val);
+    if (wildCardStringindex > -1) {
+      directories.splice(wildCardStringindex, 1);
+    }
+  });
+
   let walk = function(directory) {
+
     // Look at the contents of the directory.
     return fs.readdirAsync(directory).then(relnames => {
+
       // If there are no files/folders, declare success.
       if (relnames.length === 0) {
         return Promise.resolve([]);
@@ -81,6 +114,15 @@ let traverse = function(directories, options) {
       // Otherwise, loop through directory contents.
       return Promise.all(
         relnames.map(fileName => {
+
+          
+          // If The directory name contains a wildcard character
+          // search all directory names with the preceding characters.
+          let wildcard = '*';
+          if (relnames.indexOf(wildcard) !== -1) {
+
+
+          } 
           let name = path.join(directory, fileName);
 
           // Check if the directory item is a directory or file.

--- a/lib/traverse.js
+++ b/lib/traverse.js
@@ -115,14 +115,6 @@ let traverse = function(directories, options) {
       return Promise.all(
         relnames.map(fileName => {
 
-          
-          // If The directory name contains a wildcard character
-          // search all directory names with the preceding characters.
-          let wildcard = '*';
-          if (relnames.indexOf(wildcard) !== -1) {
-
-
-          } 
           let name = path.join(directory, fileName);
 
           // Check if the directory item is a directory or file.


### PR DESCRIPTION
This pull request allows you to enter values with a wildcard '*' in the source array of your kss-config.json file: 

```
{
  "source": [
    "scss",
    "node_modules/schnell-*",
  ],
}
```

Which would match values like this

node_modules/schnell-1
node_modules/schnell-banana

etc.