### PR TITLE
Fix #439: Markup Files Naming Conflicts

### DIFF
--- a/builder/base/handlebars/kss_builder_base_handlebars.js
+++ b/builder/base/handlebars/kss_builder_base_handlebars.js
@@ -15,6 +15,7 @@ const KssBuilderBase = require('../kss_builder_base.js'),
   Handlebars = require('handlebars');
 
 const fs = Promise.promisifyAll(require('fs-extra'));
+const crypto = require('crypto');
 
 /**
  * A kss-node builder takes input files and builds a style guide using
@@ -133,8 +134,8 @@ class KssBuilderBaseHandlebars extends KssBuilderBase {
     };
     // Converts a filename into a Handlebars partial name.
     options.filenameToTemplateRef = filename => {
-      // Return the filename without the full path or the file extension.
-      return path.basename(filename, path.extname(filename));
+      // Return hash by full path.
+      return crypto.createHash('md5').update(filename).digest("hex");
     };
     options.templateExtension = 'hbs';
     options.emptyTemplate = '{{! Cannot be an empty string. }}';

--- a/builder/base/kss_builder_base.js
+++ b/builder/base/kss_builder_base.js
@@ -840,6 +840,8 @@ class KssBuilderBase {
               files: files
             };
           };
+
+          findTemplates.push(glob(source + '/**/' + path.join(path.dirname(section.sourceFileName()), template.file)).then(returnFilesAndSource));
           findTemplates.push(glob(source + '/**/' + template.file).then(returnFilesAndSource));
           findTemplates.push(glob(source + '/**/' + path.join(path.dirname(template.file), matchExampleFilename)).then(returnFilesAndSource));
         });
@@ -859,6 +861,7 @@ class KssBuilderBase {
                     foundTemplate = true;
                     section.custom('markupFile', path.relative(source, file));
                     template.file = file;
+                    template.name = filenameToTemplateRef(file);
                     loadTemplates.push(
                       readSectionTemplate(template.name, file).then(() => {
                         /* eslint-disable max-nested-callbacks */

--- a/builder/base/nunjucks/kss_builder_base_nunjucks.js
+++ b/builder/base/nunjucks/kss_builder_base_nunjucks.js
@@ -18,6 +18,7 @@ const nunjucks = require('nunjucks');
 const Promise = require('bluebird');
 
 const fs = Promise.promisifyAll(require('fs-extra'));
+const crypto = require('crypto');
 
 // Define "KssBuilderBaseNunjucks" as the name of our nunjucks builder class.
 //
@@ -165,8 +166,8 @@ class KssBuilderBaseNunjucks extends KssBuilderBase {
 
     // Converts a filename into a Handlebars partial name.
     options.filenameToTemplateRef = (filename) => {
-      // Return the filename without the full path or the file extension.
-      return path.basename(filename, path.extname(filename));
+      // Return hash by full path.
+      return crypto.createHash('md5').update(filename).digest("hex");
     };
 
     return this.buildGuide(styleGuide, options);

--- a/builder/base/twig/kss_builder_base_twig.js
+++ b/builder/base/twig/kss_builder_base_twig.js
@@ -15,6 +15,7 @@ const KssBuilderBase = require('../kss_builder_base.js'),
   Twig = require('twig');
 
 const fs = Promise.promisifyAll(require('fs-extra'));
+const crypto = require('crypto');
 
 /**
  * A kss-node builder takes input files and builds a style guide using
@@ -244,8 +245,8 @@ class KssBuilderBaseTwig extends KssBuilderBase {
     };
     // Converts a filename into a Twig template name.
     options.filenameToTemplateRef = filename => {
-      // Return the filename without the full path.
-      return path.basename(filename);
+      // Return hash by full path.
+      return crypto.createHash('md5').update(filename).digest("hex");
     };
     options.templateExtension = 'twig';
     options.emptyTemplate = '{# Cannot be an empty string. #}';


### PR DESCRIPTION
Fix naming conflicts in Twig, Nunjucks and Handlebars.