### PR TITLE
Allow builder from an external node_module

### DIFF
--- a/builder/base/twig/kss_builder_base_twig.js
+++ b/builder/base/twig/kss_builder_base_twig.js
@@ -44,7 +44,7 @@ class KssBuilderBaseTwig extends KssBuilderBase {
         boolean: true,
         default: false,
         multiple: false,
-        describe: 'Extend Twig.js using kss\'s Drupal 8 extensions'
+        describe: 'Extend Twig.js using kss’s Drupal 8 extensions'
       },
       'namespace': {
         group: 'Style guide:',
@@ -69,7 +69,7 @@ class KssBuilderBaseTwig extends KssBuilderBase {
     return super.prepare(styleGuide).then(styleGuide => {
       // Collect the namespaces to be used by Twig.
       this.namespaces = {
-        builderTwig: path.resolve(this.options.builder)
+        builderTwig: this.options.builder
       };
       this.options.namespace.forEach(namespace => {
         // namespace should be of the form "namespace:path";

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "handlebars": "^4.0.0",
     "marked": "^0.3.6",
     "nunjucks": "^3.0.1",
+    "resolve": "^1.6.0",
     "twig": "^1.10.4",
     "twig-drupal-filters": "^1.0.0",
     "yargs": "^11.0.0"


### PR DESCRIPTION
I should find a way to resolve path of builder without `paths` option of `require.resolve` for compatibility with node < 8.9