### PR TITLE
Remove erroneous closing parentheses

### DIFF
--- a/builder/handlebars/kss-assets/kss-fullscreen.js
+++ b/builder/handlebars/kss-assets/kss-fullscreen.js
@@ -30,7 +30,7 @@
     for (var button of elementList) {
       // Get the section reference from the data attribute.
       button.onclick = self.setFocus.bind(self, button.dataset.kssFullscreen);
-    });
+    };
   };
 
   // Activation function that takes the ID of the element that will receive

--- a/builder/handlebars/kss-assets/kss-guides.js
+++ b/builder/handlebars/kss-assets/kss-guides.js
@@ -13,7 +13,7 @@
     var elementList = document.querySelectorAll('a[data-kss-guides]');
     for (var button of elementList) {
       button.onclick = self.showGuides.bind(self);
-    });
+    };
   };
 
   // Toggle the guides mode.

--- a/builder/handlebars/kss-assets/kss-markup.js
+++ b/builder/handlebars/kss-assets/kss-markup.js
@@ -14,7 +14,7 @@
     var elementList = document.querySelectorAll('a[data-kss-markup]');
     for (var button of elementList) {
       button.onclick = self.showGuides.bind(self);
-    });
+    };
   };
 
   // Activation function that takes the ID of the element that will receive
@@ -30,7 +30,7 @@
       } else {
         el.setAttribute('open', '');
       }
-    });
+    };
 
     // Toggle the markup mode.
     body.classList.toggle(this.bodyClass);


### PR DESCRIPTION
The default code in the handlebars builder has some extra parentheses that are causing errors.
This PR removes them.