### PR TITLE
Fix forgoten colors in toJSON function

### DIFF
--- a/lib/kss_section.js
+++ b/lib/kss_section.js
@@ -99,6 +99,7 @@ class KssSection {
       referenceNumber: this.referenceNumber(),
       referenceURI: this.referenceURI(),
       weight: this.weight(),
+      colors: this.colors(),
       markup: this.markup(),
       source: this.source(),
       // Include meta as well.

--- a/test/test_kss_section.js
+++ b/test/test_kss_section.js
@@ -102,7 +102,8 @@ describe('KssSection object API', function() {
         header: 'example',
         description: 'lorem ipsum',
         reference: '1.1',
-        markup: '<div class="example">lorem ipsum</div>'
+        markup: '<div class="example">lorem ipsum</div>',
+        colors: []
       };
       let section = new kss.KssSection(data);
       for (let property in data) {

--- a/test/test_kss_style_guide.js
+++ b/test/test_kss_style_guide.js
@@ -77,6 +77,7 @@ describe('KssStyleGuide object API', function() {
             experimental: false,
             header: 'example',
             markup: '<div class="example">lorem ipsum</div>',
+            colors: [],
             modifiers: [],
             parameters: [],
             reference: '1.1',


### PR DESCRIPTION
Colors was missing from output of toJSON section function.
This pull request fix this oversight.