### PR TITLE
Add the raw-filter to prevent the markup from being encapsulated in quotes

### DIFF
--- a/builder/twig/index.twig
+++ b/builder/twig/index.twig
@@ -223,7 +223,7 @@
                 Markup
               {% endif %}
             </summary>
-            <pre class="hljs"><code class="language-twig">{{ section.markup|hljs('twig') }}</code></pre>
+            <pre class="hljs"><code class="language-twig">{{ section.markup|hljs('twig')|raw }}</code></pre>
           </details>
         {% endif %}
       {% endif %}


### PR DESCRIPTION
Solves an Twig-builder-issue where you see this:

```html
<button class="btn btn-primary>Test</button>
```

Instead of this:
```html
<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"btn btn-primary"</span>&gt;</span>Test<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span></span>
```
