### PR TITLE
Duplicate template ID's cause mixup on render

### DIFF
--- a/builder/base/twig/kss_builder_base_twig.js
+++ b/builder/base/twig/kss_builder_base_twig.js
@@ -245,7 +245,7 @@ class KssBuilderBaseTwig extends KssBuilderBase {
     // Converts a filename into a Twig template name.
     options.filenameToTemplateRef = filename => {
       // Return the filename without the full path.
-      return path.basename(filename);
+      return md5(filename);
     };
     options.templateExtension = 'twig';
     options.emptyTemplate = '{# Cannot be an empty string. #}';


### PR DESCRIPTION
# Problem
I have a few templates that have the same name but are stored in different directories. When rendering the KSS Styleguide only one of the same-named templates is used for each component even though they have different markup. 

# Proposed solution
Change template id from filename to md5 hash of path or some other way to uniquely identify a template other than by filename.

# Missing in the PR
A dependency to md5 in package.json