### PR TITLE
Avoid writing files that have not changed its contents

### DIFF
--- a/builder/base/kss_builder_base.js
+++ b/builder/base/kss_builder_base.js
@@ -1192,11 +1192,23 @@ class KssBuilderBase {
       }
 
       return getHomepageText.then(() => {
+        const filePath = path.join(this.options.destination, fileName);
+        const fileContent = templateRender(this.templates[templateName], context);
+
+        const isFileAlreadyExisting = fs.existsSync(filePath);
+
+        // check if the file already exists
+        if (isFileAlreadyExisting) {
+          const existingFileContent = fs.readFileSync(filePath, 'utf8');
+
+          // don't write the file if the content is the same
+          if (existingFileContent === fileContent) {
+            return Promise.resolve();
+          }
+        }
+
         // Render the template and save it to the destination.
-        return fs.writeFileAsync(
-          path.join(this.options.destination, fileName),
-          templateRender(this.templates[templateName], context)
-        );
+        return fs.writeFileAsync(filePath, fileContent);
       });
     });
   }


### PR DESCRIPTION
Currently, the HTML files are written even if they already exist before and only one file has changed. This pull request checks if the content is identical before the write action and then skips the write action.